### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,13 +15,13 @@ buildscript {
     
         add(new org.apache.ivy.plugins.resolver.URLResolver()) {
             name = "GitHub"
-            addIvyPattern 'http://cloud.github.com/downloads/costin/gradle-stuff/[organization].[module]-[artifact]-[revision].[ext]'
-            addArtifactPattern 'http://cloud.github.com/downloads/costin/gradle-stuff/[organization].[module]-[revision].[ext]'
+            addIvyPattern 'https://cloud.github.com/downloads/costin/gradle-stuff/[organization].[module]-[artifact]-[revision].[ext]'
+            addArtifactPattern 'https://cloud.github.com/downloads/costin/gradle-stuff/[organization].[module]-[revision].[ext]'
         }
         mavenCentral()
         mavenLocal()
-        mavenRepo name: "springsource-org-release", urls: "http://repository.springsource.com/maven/bundles/release"
-        mavenRepo name: "springsource-org-external", urls: "http://repository.springsource.com/maven/bundles/external"
+        mavenRepo name: "springsource-org-release", urls: "https://repository.springsource.com/maven/bundles/release"
+        mavenRepo name: "springsource-org-external", urls: "https://repository.springsource.com/maven/bundles/external"
     }
 
     dependencies {
@@ -42,14 +42,14 @@ allprojects {
         mavenLocal()
         mavenCentral()
         // Public Spring artefacts
-        mavenRepo name: "springsource-org-release", urls: "http://repository.springsource.com/maven/bundles/release"
-        mavenRepo name: "spring-release", urls: "http://maven.springframework.org/release"
-        mavenRepo name: "spring-milestone", urls: "http://maven.springframework.org/milestone"
-        mavenRepo name: "spring-snapshot", urls: "http://maven.springframework.org/snapshot"
-        mavenRepo name: "sonatype-snapshot", urls: "http://oss.sonatype.org/content/repositories/snapshots"
-        mavenRepo name: "jboss", urls: "http://repository.jboss.org/maven2/"
-        mavenRepo name: "java.net", urls: "http://download.java.net/maven/2/"
-        mavenRepo name: "ext-snapshots", urls: "http://springframework.svn.sourceforge.net/svnroot/springframework/repos/repo-ext/"
+        mavenRepo name: "springsource-org-release", urls: "https://repository.springsource.com/maven/bundles/release"
+        mavenRepo name: "spring-release", urls: "https://maven.springframework.org/release"
+        mavenRepo name: "spring-milestone", urls: "https://maven.springframework.org/milestone"
+        mavenRepo name: "spring-snapshot", urls: "https://maven.springframework.org/snapshot"
+        mavenRepo name: "sonatype-snapshot", urls: "https://oss.sonatype.org/content/repositories/snapshots"
+        mavenRepo name: "jboss", urls: "https://repository.jboss.org/maven2/"
+        mavenRepo name: "java.net", urls: "https://download.java.net/maven/2/"
+        mavenRepo name: "ext-snapshots", urls: "https://springframework.svn.sourceforge.net/svnroot/springframework/repos/repo-ext/"
 	}
 
 }
@@ -117,9 +117,9 @@ javadoc {
       ]
   
      links = [
-        "http://static.springframework.org/spring/docs/3.0.x/javadoc-api",
-        "http://download.oracle.com/javase/6/docs/api",
-        "http://jackson.codehaus.org/1.8.2/javadoc"
+        "https://docs.spring.io/spring/docs/3.0.x/javadoc-api",
+        "https://download.oracle.com/javase/6/docs/api",
+        "https://jackson.codehaus.org/1.8.2/javadoc"
      ]
      
      exclude "org/springframework/data/document/couchdb/config/**"

--- a/maven.gradle
+++ b/maven.gradle
@@ -108,7 +108,7 @@ def customizePom(pom) {
         licenses {
             license {
                 name 'The Apache Software License, Version 2.0'
-                url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                 distribution 'repo'
             }
         }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://cloud.github.com/downloads/costin/gradle-stuff/ (UnknownHostException) migrated to:  
  https://cloud.github.com/downloads/costin/gradle-stuff/ ([https](https://cloud.github.com/downloads/costin/gradle-stuff/) result UnknownHostException).
* http://jackson.codehaus.org/1.8.2/javadoc (UnknownHostException) migrated to:  
  https://jackson.codehaus.org/1.8.2/javadoc ([https](https://jackson.codehaus.org/1.8.2/javadoc) result UnknownHostException).
* http://download.java.net/maven/2/ (301) migrated to:  
  https://download.java.net/maven/2/ ([https](https://download.java.net/maven/2/) result 404).
* http://repository.springsource.com/maven/bundles/external (404) migrated to:  
  https://repository.springsource.com/maven/bundles/external ([https](https://repository.springsource.com/maven/bundles/external) result 404).
* http://repository.springsource.com/maven/bundles/release (404) migrated to:  
  https://repository.springsource.com/maven/bundles/release ([https](https://repository.springsource.com/maven/bundles/release) result 404).
* http://springframework.svn.sourceforge.net/svnroot/springframework/repos/repo-ext/ (404) migrated to:  
  https://springframework.svn.sourceforge.net/svnroot/springframework/repos/repo-ext/ ([https](https://springframework.svn.sourceforge.net/svnroot/springframework/repos/repo-ext/) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://repository.jboss.org/maven2/ migrated to:  
  https://repository.jboss.org/maven2/ ([https](https://repository.jboss.org/maven2/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://static.springframework.org/spring/docs/3.0.x/javadoc-api (301) migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/javadoc-api ([https](https://static.springframework.org/spring/docs/3.0.x/javadoc-api) result 301).
* http://download.oracle.com/javase/6/docs/api migrated to:  
  https://download.oracle.com/javase/6/docs/api ([https](https://download.oracle.com/javase/6/docs/api) result 302).
* http://maven.springframework.org/milestone migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://maven.springframework.org/release migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).
* http://maven.springframework.org/snapshot migrated to:  
  https://maven.springframework.org/snapshot ([https](https://maven.springframework.org/snapshot) result 302).
* http://oss.sonatype.org/content/repositories/snapshots migrated to:  
  https://oss.sonatype.org/content/repositories/snapshots ([https](https://oss.sonatype.org/content/repositories/snapshots) result 302).