### PR TITLE
URL Cleanup

### DIFF
--- a/docs/src/reference/docbook/introduction/getting-started.xml
+++ b/docs/src/reference/docbook/introduction/getting-started.xml
@@ -17,21 +17,21 @@
 		  
 		<section id="get-started:first-steps:spring">
 			<title>Knowing Spring</title>
-			<para>Spring Data uses heavily Spring framework's <ulink url="http://static.springframework.org/spring/docs/3.0.x/reference/spring-core.html">core</ulink> functionality, 
-			such as the <ulink url="http://static.springframework.org/spring/docs/3.0.x/reference/beans.html">IoC</ulink> container,
-			<ulink url="http://static.springframework.org/spring/docs/3.0.x/reference/resources.html">resource</ulink> abstract or
-			<ulink url="http://static.springframework.org/spring/docs/3.0.x/reference/aop.html">AOP</ulink> infrastructure. While it is not important
+			<para>Spring Data uses heavily Spring framework's <ulink url="https://docs.spring.io/spring/docs/3.0.x/reference/spring-core.html">core</ulink> functionality, 
+			such as the <ulink url="https://docs.spring.io/spring/docs/3.0.x/reference/beans.html">IoC</ulink> container,
+			<ulink url="https://docs.spring.io/spring/docs/3.0.x/reference/resources.html">resource</ulink> abstract or
+			<ulink url="https://docs.spring.io/spring/docs/3.0.x/reference/aop.html">AOP</ulink> infrastructure. While it is not important
 			to know the Spring APIs, understanding the concepts behind them is. At a minimum, the idea behind IoC should be familiar.
 			These being said, the more knowledge one has about the Spring, the faster she will pick Spring Data Key Value.
 			Besides the very comprehensive (and sometimes disarming) documentation that explains in detail the Spring Framework,
 			there are a lot of articles, blog entries and books on the matter - take a look at the Spring framework
-			<ulink url="http://www.springsource.org/documentation">home page</ulink> for more information. In general, this should be the starting point for 
+			<ulink url="https://www.springsource.org/documentation">home page</ulink> for more information. In general, this should be the starting point for 
 			developers wanting to try Spring DKV.</para>
 		</section>
 		<section id="get-started:first-steps:nosql">
 			<title>Knowing NoSQL and Key Value stores</title>
 			<para>NoSQL stores have taken the storage world by storm. It is a vast domain with a plethora of solutions, terms and patterns (to make things worth even the
-			term itself has multiple <ulink url="http://www.google.com/search?q=nosoql+acronym">meanings</ulink>).
+			term itself has multiple <ulink url="https://www.google.com/search?q=nosoql+acronym">meanings</ulink>).
 			While some of the principles are common, it is crucial that the user is familiar to some degree with the stores supported by SDKV.
 			The best way to get acquainted to this solutions is to read their documentation and follow their examples - it usually doesn't take more then 5-10 minutes
 			to go through them and if you are coming from an RDMBS-only background many times these exercises can be an eye opener. 
@@ -40,11 +40,11 @@
 		<section id="get-started:first-steps:samples">
 			<title>Trying Out The Samples</title>
 			<para>One can find various samples for key value stores in the dedicated example repo, at 
-			<ulink url="https://github.com/SpringSource/spring-data-keyvalue-examples">http://github.com/SpringSource/spring-data-keyvalue-examples</ulink>. For Spring Redis,
+			<ulink url="https://github.com/SpringSource/spring-data-keyvalue-examples">https://github.com/SpringSource/spring-data-keyvalue-examples</ulink>. For Spring Redis,
 			of interest is the <literal>retwisj</literal> sample, a Twitter-clone built on top of Redis which can be run locally or be deployed into the cloud. See its 
-			<ulink url="http://static.springsource.org/spring-data/data-keyvalue/examples/retwisj/current/">documentation</ulink>, the following blog 
-			<ulink url="http://blog.springsource.com/2011/04/27/getting-started-redis-spring-cloud-foundry/">entry</ulink> or the 
-			<ulink url="http://retwisj.cloudfoundry.com/">live instance</ulink> for more information.</para>
+			<ulink url="https://docs.spring.io/spring-data/data-keyvalue/examples/retwisj/current/">documentation</ulink>, the following blog 
+			<ulink url="https://spring.io/blog/2011/04/27/getting-started-redis-spring-cloud-foundry/">entry</ulink> or the 
+			<ulink url="https://retwisj.cloudfoundry.com/">live instance</ulink> for more information.</para>
 		</section>
 	</section>
     
@@ -55,13 +55,13 @@
 		
 		<section id="get-started:help:community">
   		    <title>Community Support</title>
-			<para>The Spring Data <ulink url="http://forum.springframework.org/forumdisplay.php?f=80">forum</ulink> is a message board for all Spring Data (not just Key Value) users to
+			<para>The Spring Data <ulink url="https://forum.springframework.org/forumdisplay.php?f=80">forum</ulink> is a message board for all Spring Data (not just Key Value) users to
 			share information and help each other. Note that registration is needed <emphasis>only</emphasis> for posting.
 			</para>
 		</section>
 		<section id="get-started:help:professional">
   		    <title>Professional Support</title>
-			<para>Professional, from-the-source support, with guaranteed response time, is available from <ulink url="http://www.springsource.com">SpringSource</ulink>,
+			<para>Professional, from-the-source support, with guaranteed response time, is available from <ulink url="https://www.springsource.com">SpringSource</ulink>,
 			the company behind Spring Data and Spring.  
 			</para>
 		</section>
@@ -71,16 +71,16 @@
 		<title>Following Development</title>
 		
 		<para>For information on the Spring Data source code repository, nightly builds and snapshot artifacts please see the Spring Data home 
-		<ulink url="http://www.springsource.org/spring-data">page</ulink>.   
+		<ulink url="https://www.springsource.org/spring-data">page</ulink>.   
 		</para>
 		<para>You can help make Spring Data best serve the needs of the Spring community by interacting with developers through the Spring Community 
-		<ulink url="http://forum.springsource.org">forums</ulink>.</para>
+		<ulink url="https://forum.spring.io/">forums</ulink>.</para>
 		<para>If you encounter a bug or want to suggest an improvement, 
 		please create a ticket on the Spring Data issue <ulink url="https://jira.springframework.org/browse/DATAKV">tracker</ulink>.</para>
 		<para>To stay up to date with the latest news and announcements in the Spring eco system, subscribe to the 
-		Spring Community <ulink url="http://www.springframework.org/">Portal</ulink>.</para>
-		<para>Lastly, you can follow the SpringSource Data <ulink url="http://blog.springsource.com/category/data-access/">blog</ulink> or the project team on Twitter 
-		(<ulink url="http://twitter.com/costinl">Costin</ulink>)</para>
+		Spring Community <ulink url="https://www.springframework.org/">Portal</ulink>.</para>
+		<para>Lastly, you can follow the SpringSource Data <ulink url="https://spring.io/blog/category/data-access/">blog</ulink> or the project team on Twitter 
+		(<ulink url="https://twitter.com/costinl">Costin</ulink>)</para>
 	</section>
     
 </chapter>

--- a/docs/src/reference/docbook/introduction/requirements.xml
+++ b/docs/src/reference/docbook/introduction/requirements.xml
@@ -2,10 +2,10 @@
       <title>Requirements</title>
 
       <para>Spring Data Redis 1.x binaries requires JDK level 6.0 and above, 
-      and <ulink url="http://www.springsource.org/documentation">Spring Framework</ulink>
+      and <ulink url="https://www.springsource.org/documentation">Spring Framework</ulink>
       3.0.x and above.</para>
       <para>
-      In terms of key value stores, <ulink url="http://code.google.com/p/redis/">Redis</ulink> 2.2.x 
+      In terms of key value stores, <ulink url="https://code.google.com/p/redis/">Redis</ulink> 2.2.x 
       is required.
       </para>
   </chapter>

--- a/docs/src/reference/docbook/introduction/why-sdr.xml
+++ b/docs/src/reference/docbook/introduction/why-sdr.xml
@@ -7,7 +7,7 @@
     non-invasive programming model enabled by the use of dependency
     injection, AOP, and portable service abstractions.</para>
     
-    <para><ulink url="http://en.wikipedia.org/wiki/NoSQL">NoSQL</ulink>
+    <para><ulink url="https://en.wikipedia.org/wiki/NoSQL">NoSQL</ulink>
     storages provide an alternative to classical RDBMS for horizontal scalability
     and speed. In terms of implementation, Key Value stores represent one of the
     largest (and oldest) member in the NoSQL space.</para>

--- a/docs/src/reference/docbook/reference/redis-messaging.xml
+++ b/docs/src/reference/docbook/reference/redis-messaging.xml
@@ -149,8 +149,8 @@ template.convertAndSend("hello!", "world");]]></programlisting>
 &lt;beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     <lineannotation>xmlns:redis="http://www.springframework.org/schema/redis"</lineannotation>
-    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        <lineannotation>http://www.springframework.org/schema/redis http://www.springframework.org/schema/redis/spring-redis.xsd"</lineannotation>&gt;
+    xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        <lineannotation>http://www.springframework.org/schema/redis https://www.springframework.org/schema/redis/spring-redis.xsd"</lineannotation>&gt;
 
   &lt;!-- the default ConnectionFactory --&gt;
   &lt;redis:listener-container&gt;

--- a/docs/src/reference/docbook/reference/redis.xml
+++ b/docs/src/reference/docbook/reference/redis.xml
@@ -2,7 +2,7 @@
 <chapter xmlns="http://docbook.org/ns/docbook" version="5.0"  xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="redis">
   <title>Redis support</title>
 
-  <para>One of the key value stores supported by Spring Data is <ulink url="http://redis.io">Redis</ulink>.
+  <para>One of the key value stores supported by Spring Data is <ulink url="https://redis.io">Redis</ulink>.
   To quote the project home page:
   <quote>
   Redis is an advanced key-value store. It is similar to memcached but the dataset is not volatile, and values can be strings,
@@ -17,8 +17,8 @@
   <section id="redis:requirements">
     <title>Redis Requirements</title>
     <para>Spring Redis requires Redis 2.0 or above (Redis 2.2 is recommended) and Java SE 6.0 or above.
-    In terms of language bindings (or connectors), Spring Redis integrates with <ulink url="http://github.com/xetorthio/jedis">Jedis</ulink>,  
-    <ulink url="http://github.com/alphazero/jredis">JRedis</ulink> and <ulink url="http://github.com/e-mzungu/rjc">RJC</ulink>, three popular open source Java libraries for Redis. 
+    In terms of language bindings (or connectors), Spring Redis integrates with <ulink url="https://github.com/xetorthio/jedis">Jedis</ulink>,  
+    <ulink url="https://github.com/alphazero/jredis">JRedis</ulink> and <ulink url="https://github.com/e-mzungu/rjc">RJC</ulink>, three popular open source Java libraries for Redis. 
     If you are aware of any other connector that we should be integrating is, please send us feedback.
     </para>
   </section>
@@ -34,7 +34,7 @@
       <xref linkend="redis:template"/> explains the abstraction builds on top of the low-level <interfacename>Connection</interfacename> API to handle the 
       infrastructural concerns and object conversion.</listitem>
       <listitem><emphasis>Support Classes</emphasis> - that offer reusable components (built on the aforementioned abstractions) such as 
-      <interfacename>java.util.Collection</interfacename> or Spring 3.1 <ulink url="http://blog.springsource.com/2011/02/23/spring-3-1-m1-caching/">cache</ulink> implementation backed by 
+      <interfacename>java.util.Collection</interfacename> or Spring 3.1 <ulink url="https://spring.io/blog/2011/02/23/spring-3-1-m1-caching/">cache</ulink> implementation backed by 
       Redis as documented in <xref linkend="redis:support"/></listitem>
     </itemizedlist>
     
@@ -56,7 +56,7 @@
         
         <para><interfacename>RedisConnection</interfacename> provides the building block for Redis communication as it handles the communication with the Redis back-end. 
         It also automatically translates the underlying connecting library exceptions to Spring's consistent DAO exception 
-        <ulink url="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/dao.html#dao-exceptions">hierarchy</ulink> so one can switch the connectors
+        <ulink url="https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/dao.html#dao-exceptions">hierarchy</ulink> so one can switch the connectors
         without any code changes as the operation semantics remain the same.</para>
         
         <note>For the corner cases where the native library API is required, <interfacename>RedisConnection</interfacename> provides a dedicated method 
@@ -65,7 +65,7 @@
         <para>Active <interfacename>RedisConnection</interfacename> are created through <interfacename>RedisConnectionFactory</interfacename>. In addition, the factories act as
         <interfacename>PersistenceExceptionTranslator</interfacename> meaning once declared, allow one to do transparent exception translation for example through the use of the
         <literal>@Repository</literal> annotation and AOP. For more information see the dedicated 
-        <ulink url="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/orm.html#orm-exception-translation">section</ulink> in Spring Framework documentation.</para>
+        <ulink url="https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/orm.html#orm-exception-translation">section</ulink> in Spring Framework documentation.</para>
         
         <note>Depending on the underlying configuration, the factory can return a new connection or an existing connection (in case a pool is used).</note>
       </section>
@@ -86,14 +86,14 @@
       <section id="redis:connectors:jedis">
         <title>Configuring Jedis connector</title>
         
-        <para><ulink url="http://github.com/xetorthio/jedis">Jedis</ulink> is one of the connectors supported by the Key Value module through the 
+        <para><ulink url="https://github.com/xetorthio/jedis">Jedis</ulink> is one of the connectors supported by the Key Value module through the 
         <literal>org.springframework.data.redis.connection.jedis</literal> package. In its simples form, the Jedis configuration looks as follow:</para>
         
         <programlisting language="xml"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
     
     <!-- Jedis ConnectionFactory -->
   <bean id="jedisConnectionFactory" class="org.springframework.data.redis.connection.jedis.JedisConnectionFactory"/>
@@ -106,7 +106,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:p="http://www.springframework.org/schema/p"
   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
     
   <bean id="jedisConnectionFactory" class="org.springframework.data.redis.connection.jedis.JedisConnectionFactory"
         p:host-name="server" p:port="6379"/>
@@ -117,10 +117,10 @@
       <section id="redis:connectors:jredis">
         <title>Configuring JRedis connector</title>
         
-        <para><ulink url="http://github.com/alphazero/jredis">JRedis</ulink> is another popular, open-source connector supported by Spring Redis through the
+        <para><ulink url="https://github.com/alphazero/jredis">JRedis</ulink> is another popular, open-source connector supported by Spring Redis through the
         <literal>org.springframework.data.redis.connection.jredis</literal> package.</para> 
         <note>Since JRedis itself does not support (yet) Redis 2.x commands, Spring Redis uses an updated fork available 
-        <ulink url="http://github.com/anthonylauzon/jredis">here</ulink>.</note>
+        <ulink url="https://github.com/anthonylauzon/jredis">here</ulink>.</note>
         
         <para>A typical JRedis configuration can looks like this:</para>
 
@@ -129,7 +129,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:p="http://www.springframework.org/schema/p"
   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
     
   <bean id="jredisConnectionFactory" class="org.springframework.data.redis.connection.jredis.JredisConnectionFactory"
         p:host-name="server" p:port="6379"/>
@@ -138,7 +138,7 @@
       <para>As one can note, the configuration is quite similar to the Jedis one.</para>
       
       <important><para>Currently, JRedis does not have support for binary keys. This forces the <classname>JredisConnection</classname> to perform encoding internally
-      (through <ulink url="http://en.wikipedia.org/wiki/Base64">base64</ulink> schema). In practice, this means it's safe to read/write arbitrary data however 
+      (through <ulink url="https://en.wikipedia.org/wiki/Base64">base64</ulink> schema). In practice, this means it's safe to read/write arbitrary data however 
       the Redis key stored values will differ from the decoded ones, even in the simplest cases, since everything (no matter the format) is encoded. This will not be
       the case for Redis values.</para>
       <para>This issue is currently being addressed in the JRedis project and once fixed, will be incorporated by Spring Data Redis.</para>  
@@ -149,7 +149,7 @@
       <section id="redis:connectors:rjc">
         <title>Configuring RJC connector</title>
         
-        <para><ulink url="http://github.com/e-mzungu/rjc">RJC</ulink> is the third, open-source connector supported by Spring Redis through the
+        <para><ulink url="https://github.com/e-mzungu/rjc">RJC</ulink> is the third, open-source connector supported by Spring Redis through the
         <literal>org.springframework.data.redis.connection.rjc</literal> package.</para> 
         
         <para>Similar to the other connectors, a typical RJC configuration can looks like this:</para>
@@ -159,7 +159,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:p="http://www.springframework.org/schema/p"
   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
     
   <bean id="jredisConnectionFactory" class="org.springframework.data.redis.connection.rjc.RjcConnectionFactory"
         p:host-name="server" p:port="6379"/>
@@ -168,7 +168,7 @@
       <para>As one can note, the configuration is quite similar to the Jredis or Jedis one.</para>
       
       <important><para>Currently, RJC does not have support for binary keys. This forces the <classname>RjcConnection</classname> to perform encoding internally
-      (through <ulink url="http://en.wikipedia.org/wiki/Base64">base64</ulink> schema). In practice, this means it's safe to read/write arbitrary data however 
+      (through <ulink url="https://en.wikipedia.org/wiki/Base64">base64</ulink> schema). In practice, this means it's safe to read/write arbitrary data however 
       the Redis key stored values will differ from the decoded ones, even in the simplest cases, since everything (no matter the format) is encoded. This will not be
       the case for Redis values.</para>
       <para>This issue is currently being addressed in the RJC project and once fixed, will be incorporated by Spring Data Redis.</para>  
@@ -186,7 +186,7 @@
       The template offers a high-level abstraction for Redis interaction - while <interfacename>RedisConnection</interfacename> offer low level methods that accept and return
       binary values (<literal>byte</literal> arrays), the template takes care of serialization and connection management, freeing the user from dealing with such details.</para>
       
-      <para>Moreover, the template provides operations views (following the grouping from Redis command <ulink url="http://redis.io/commands">reference</ulink>)
+      <para>Moreover, the template provides operations views (following the grouping from Redis command <ulink url="https://redis.io/commands">reference</ulink>)
       that offer rich, generified interfaces for working against a certain type or certain key (through the <interfacename>KeyBound</interfacename> interfaces) as described below:</para>
       
       <table  id="redis-template-operations-view" pgwide="1">
@@ -269,7 +269,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:p="http://www.springframework.org/schema/p"
   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
     
   <bean id="jedisConnectionFactory" class="org.springframework.data.redis.connection.jedis.JedisConnectionFactory"
         p:use-pool="true"/>
@@ -313,7 +313,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:p="http://www.springframework.org/schema/p"
   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
     
   <bean id="jedisConnectionFactory" class="org.springframework.data.redis.connection.jedis.JedisConnectionFactory"
         p:use-pool="true"/>
@@ -359,8 +359,8 @@
 	  (package <literal>org.springframework.data.redis.serializer</literal>) which as the name implies, takes care of the serialization process. Multiple implementations are
 	  available out of the box, two of which have been already mentioned before in this documentation: the <literal>StringRedisSerializer</literal> and 
 	  the <literal>JdkSerializationRedisSerializer</literal>. However one can use <classname>OxmSerializer</classname> for Object/XML mapping through Spring 3 
-	  <ulink url="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/oxm.html">OXM</ulink> support or <classname>JacksonJsonRedisSerializer</classname> for storing
-	  data in <ulink url="http://en.wikipedia.org/wiki/JSON">JSON</ulink> format. Do note that the storage format is not limited only to values - it can be used for keys, values or hashes
+	  <ulink url="https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/oxm.html">OXM</ulink> support or <classname>JacksonJsonRedisSerializer</classname> for storing
+	  data in <ulink url="https://en.wikipedia.org/wiki/JSON">JSON</ulink> format. Do note that the storage format is not limited only to values - it can be used for keys, values or hashes
 	  without any restrictions.</para>
 	</section>
 	
@@ -370,8 +370,8 @@
       <title>Support Classes</title>
       
       <para>Package <literal>org.springframework.data.redis.support</literal> offers various reusable components that rely on Redis as a backing store. Curently the package contains
-      various JDK-based interface implementations on top of Redis such as <ulink url="http://download.oracle.com/javase/6/docs/api/java/util/concurrent/atomic/package-summary.html">atomic</ulink> 
-      counters and JDK <interfacename><ulink url="http://download.oracle.com/javase/6/docs/api/java/util/Collection.html">Collections</ulink></interfacename>.</para>
+      various JDK-based interface implementations on top of Redis such as <ulink url="https://download.oracle.com/javase/6/docs/api/java/util/concurrent/atomic/package-summary.html">atomic</ulink> 
+      counters and JDK <interfacename><ulink url="https://download.oracle.com/javase/6/docs/api/java/util/Collection.html">Collections</ulink></interfacename>.</para>
       
       <para>The atomic counters make it easy to wrap Redis key incrementation while the collections allow easy management of Redis keys with minimal storage exposure or API leakage: in particular
       the <interfacename>RedisSet</interfacename> and <interfacename>RedisZSet</interfacename> interfaces offer easy access to the <emphasis>set</emphasis> operations supported by Redis such as
@@ -384,7 +384,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:p="http://www.springframework.org/schema/p"
   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
     
   <bean id="queue" class="org.springframework.data.redis.support.collections.DefaultRedisList">
     <constructor-arg ref="redisTemplat"/>
@@ -409,14 +409,14 @@
 	 <section id="redis:support:cache-abstraction">
         <title>Support for Spring Cache Abstraction</title>
   	
-  	<para>Spring Redis provides an implementation for Spring 3.1 <ulink url="http://static.springsource.org/spring/docs/3.1.0.M2/spring-framework-reference/html/cache.html">cache abstraction</ulink>
+  	<para>Spring Redis provides an implementation for Spring 3.1 <ulink url="https://docs.spring.io/spring/docs/3.1.0.M2/spring-framework-reference/html/cache.html">cache abstraction</ulink>
   	through the <literal>org.springframework.data.redis.cache</literal> package. To use Redis as a backing implementation, simply add <literal>RedisCacheManager</literal> to your configuration:</para>
   	
   	<programlisting language="xml"><![CDATA[<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:cache="http://www.springframework.org/schema/cache"
   xmlns:c="http://www.springframework.org/schema/c"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-      http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd">
+  xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+      http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd">
   <!-- turn on declarative caching -->
   <cache:annotation-driven />
   

--- a/src/test/resources/server-jmx.xml
+++ b/src/test/resources/server-jmx.xml
@@ -4,9 +4,9 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:p="http://www.springframework.org/schema/p"
        xmlns:couch="http://www.springframework.org/schema/data/couch"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/data/couch http://www.springframework.org/schema/data/couch/spring-couch-1.0.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/data/couch https://www.springframework.org/schema/data/couch/spring-couch-1.0.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 
   <couch:jmx/>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://retwisj.cloudfoundry.com/ (UnknownHostException) with 1 occurrences migrated to:  
  https://retwisj.cloudfoundry.com/ ([https](https://retwisj.cloudfoundry.com/) result UnknownHostException).
* http://blog.springsource.com/category/data-access/ (301) with 1 occurrences migrated to:  
  https://spring.io/blog/category/data-access/ ([https](https://blog.springsource.com/category/data-access/) result 400).
* http://blog.springsource.com/2011/02/23/spring-3-1-m1-caching/ (301) with 1 occurrences migrated to:  
  https://spring.io/blog/2011/02/23/spring-3-1-m1-caching/ ([https](https://blog.springsource.com/2011/02/23/spring-3-1-m1-caching/) result 404).
* http://blog.springsource.com/2011/04/27/getting-started-redis-spring-cloud-foundry/ (301) with 1 occurrences migrated to:  
  https://spring.io/blog/2011/04/27/getting-started-redis-spring-cloud-foundry/ ([https](https://blog.springsource.com/2011/04/27/getting-started-redis-spring-cloud-foundry/) result 404).
* http://www.springframework.org/schema/data/couch/spring-couch-1.0.xsd (404) with 1 occurrences migrated to:  
  https://www.springframework.org/schema/data/couch/spring-couch-1.0.xsd ([https](https://www.springframework.org/schema/data/couch/spring-couch-1.0.xsd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://static.springsource.org/spring-data/data-keyvalue/examples/retwisj/current/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/data-keyvalue/examples/retwisj/current/ ([https](https://static.springsource.org/spring-data/data-keyvalue/examples/retwisj/current/) result 200).
* http://static.springframework.org/spring/docs/3.0.x/reference/aop.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/reference/aop.html ([https](https://static.springframework.org/spring/docs/3.0.x/reference/aop.html) result 200).
* http://static.springframework.org/spring/docs/3.0.x/reference/beans.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/reference/beans.html ([https](https://static.springframework.org/spring/docs/3.0.x/reference/beans.html) result 200).
* http://static.springframework.org/spring/docs/3.0.x/reference/resources.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/reference/resources.html ([https](https://static.springframework.org/spring/docs/3.0.x/reference/resources.html) result 200).
* http://static.springframework.org/spring/docs/3.0.x/reference/spring-core.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/reference/spring-core.html ([https](https://static.springframework.org/spring/docs/3.0.x/reference/spring-core.html) result 200).
* http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/dao.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/dao.html ([https](https://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/dao.html) result 200).
* http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/orm.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/orm.html ([https](https://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/orm.html) result 200).
* http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/oxm.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/oxm.html ([https](https://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/oxm.html) result 200).
* http://static.springsource.org/spring/docs/3.1.0.M2/spring-framework-reference/html/cache.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.1.0.M2/spring-framework-reference/html/cache.html ([https](https://static.springsource.org/spring/docs/3.1.0.M2/spring-framework-reference/html/cache.html) result 200).
* http://en.wikipedia.org/wiki/Base64 with 2 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Base64 ([https](https://en.wikipedia.org/wiki/Base64) result 200).
* http://en.wikipedia.org/wiki/JSON with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/JSON ([https](https://en.wikipedia.org/wiki/JSON) result 200).
* http://en.wikipedia.org/wiki/NoSQL with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/NoSQL ([https](https://en.wikipedia.org/wiki/NoSQL) result 200).
* http://github.com/alphazero/jredis with 2 occurrences migrated to:  
  https://github.com/alphazero/jredis ([https](https://github.com/alphazero/jredis) result 200).
* http://github.com/anthonylauzon/jredis with 1 occurrences migrated to:  
  https://github.com/anthonylauzon/jredis ([https](https://github.com/anthonylauzon/jredis) result 200).
* http://github.com/e-mzungu/rjc with 2 occurrences migrated to:  
  https://github.com/e-mzungu/rjc ([https](https://github.com/e-mzungu/rjc) result 200).
* http://github.com/xetorthio/jedis with 2 occurrences migrated to:  
  https://github.com/xetorthio/jedis ([https](https://github.com/xetorthio/jedis) result 200).
* http://redis.io with 1 occurrences migrated to:  
  https://redis.io ([https](https://redis.io) result 200).
* http://redis.io/commands with 1 occurrences migrated to:  
  https://redis.io/commands ([https](https://redis.io/commands) result 200).
* http://twitter.com/costinl with 1 occurrences migrated to:  
  https://twitter.com/costinl ([https](https://twitter.com/costinl) result 200).
* http://www.google.com/search?q=nosoql+acronym with 1 occurrences migrated to:  
  https://www.google.com/search?q=nosoql+acronym ([https](https://www.google.com/search?q=nosoql+acronym) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.0.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 9 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/cache/spring-cache.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cache/spring-cache.xsd ([https](https://www.springframework.org/schema/cache/spring-cache.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.0.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.0.xsd) result 200).
* http://www.springframework.org/schema/redis/spring-redis.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/redis/spring-redis.xsd ([https](https://www.springframework.org/schema/redis/spring-redis.xsd) result 200).
* http://code.google.com/p/redis/ with 1 occurrences migrated to:  
  https://code.google.com/p/redis/ ([https](https://code.google.com/p/redis/) result 301).
* http://forum.springsource.org (301) with 1 occurrences migrated to:  
  https://forum.spring.io/ ([https](https://forum.springsource.org) result 301).
* http://forum.springframework.org/forumdisplay.php?f=80 with 1 occurrences migrated to:  
  https://forum.springframework.org/forumdisplay.php?f=80 ([https](https://forum.springframework.org/forumdisplay.php?f=80) result 301).
* http://github.com/SpringSource/spring-data-keyvalue-examples with 1 occurrences migrated to:  
  https://github.com/SpringSource/spring-data-keyvalue-examples ([https](https://github.com/SpringSource/spring-data-keyvalue-examples) result 301).
* http://www.springframework.org/ with 1 occurrences migrated to:  
  https://www.springframework.org/ ([https](https://www.springframework.org/) result 301).
* http://www.springsource.com with 1 occurrences migrated to:  
  https://www.springsource.com ([https](https://www.springsource.com) result 301).
* http://www.springsource.org/documentation with 2 occurrences migrated to:  
  https://www.springsource.org/documentation ([https](https://www.springsource.org/documentation) result 301).
* http://www.springsource.org/spring-data with 1 occurrences migrated to:  
  https://www.springsource.org/spring-data ([https](https://www.springsource.org/spring-data) result 301).
* http://download.oracle.com/javase/6/docs/api/java/util/Collection.html with 1 occurrences migrated to:  
  https://download.oracle.com/javase/6/docs/api/java/util/Collection.html ([https](https://download.oracle.com/javase/6/docs/api/java/util/Collection.html) result 302).
* http://download.oracle.com/javase/6/docs/api/java/util/concurrent/atomic/package-summary.html with 1 occurrences migrated to:  
  https://download.oracle.com/javase/6/docs/api/java/util/concurrent/atomic/package-summary.html ([https](https://download.oracle.com/javase/6/docs/api/java/util/concurrent/atomic/package-summary.html) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 9 occurrences
* http://www.springframework.org/schema/beans with 20 occurrences
* http://www.springframework.org/schema/c with 1 occurrences
* http://www.springframework.org/schema/cache with 2 occurrences
* http://www.springframework.org/schema/context with 2 occurrences
* http://www.springframework.org/schema/data/couch with 2 occurrences
* http://www.springframework.org/schema/p with 7 occurrences
* http://www.springframework.org/schema/redis with 2 occurrences
* http://www.w3.org/1999/xlink with 2 occurrences
* http://www.w3.org/2001/XInclude with 4 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 10 occurrences